### PR TITLE
Remove comment in ReadIterateZDF sample

### DIFF
--- a/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cs
+++ b/source/Applications/Basic/FileFormats/ReadIterateZDF/ReadIterateZDF.cs
@@ -28,7 +28,6 @@ class Program
             Console.WriteLine("Number of points: " + pointCloud.Size + "\n" + "Height: " + height
                               + ", Width: " + width);
 
-            // Iterating over the point cloud and displaying X, Y, Z, R, G, B, and SNR for central 10 x 10 pixels
             const ulong pixelsToDisplay = 10;
             Console.WriteLine(
                 "Iterating over point cloud and extracting X, Y, Z, R, G, B, and SNR for central {0} x {1} pixels",


### PR DESCRIPTION
This is to maintain the same printouts in all sample repositories.