### PR TITLE
Use settings based on which camera is connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
     - [**Capture**][Capture-url] - Capture point clouds, with color, from the Zivid camera.
     - [**Capture2D**][Capture2D-url] - Capture 2D images from the Zivid camera.
     - [**CaptureAssistant**][CaptureAssistant-url] - Use Capture Assistant to capture point clouds, with color, from the Zivid camera.
-    - [**CaptureFromFile**][CaptureFromFile-url] - Capture point clouds, with color, from the Zivid file camera.
+    - [**CaptureFromFile**][CaptureFromFile-url] - Capture point clouds, with color, from the Zivid file camera. Currently supported by Zivid One. 
     - [**CaptureWithSettingsFromYML**][CaptureWithSettingsFromYML-url] - Capture point clouds, with color, from the Zivid camera, with settings from YML file.
     - [**CaptureHDR**][CaptureHDR-url] - Capture HDR point clouds, with color, from the Zivid camera.
     - [**CaptureHDRCompleteSettings**][CaptureHDRCompleteSettings-url] - Capture point clouds, with color, from the Zivid camera with fully configured settings.
@@ -36,7 +36,7 @@ There are two main categories of samples: **Camera** and **Applications**. The s
 - **Applications**
   - **Basic**
     - **Visualization**
-      - [**CaptureFromFileVis3D**][CaptureFromFileVis3D-url] - Capture point clouds, with color, from the Zivid file camera, and visualize it.
+      - [**CaptureFromFileVis3D**][CaptureFromFileVis3D-url] - Capture point clouds, with color, from the Zivid file camera, and visualize it. Currently supported by Zivid One.
       - [**CaptureVis3D**][CaptureVis3D-url] - Capture point clouds, with color, from the Zivid camera, and visualize it.
     - **FileFormats**
       - [**ReadIterateZDF**][ReadIterateZDF-url] - Read point cloud data from a ZDF file, iterate through it, and extract individual points.

--- a/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cs
+++ b/source/Camera/Advanced/CaptureHDRLoop/CaptureHDRLoop.cs
@@ -17,11 +17,12 @@ class Program
             Console.WriteLine("Connecting to camera");
             var camera = zivid.ConnectCamera();
 
+            var cameraModel = camera.Info.ModelName.Substring(0, 9);
             int captures = 3;
             for (int i = 1; i <= captures; i++)
             {
                 var settingsFile = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
-                                   + "/Zivid/Settings/Settings0" + i + ".yml";
+                                   + "/Zivid/Settings/" + cameraModel + "/Settings0" + i + ".yml";
                 Console.WriteLine("Configuring settings from file: " + settingsFile);
                 var settings = new Zivid.NET.Settings(settingsFile);
                 Console.WriteLine(settings.Acquisitions);

--- a/source/Camera/Basic/CaptureHDR/CaptureHDR.cs
+++ b/source/Camera/Basic/CaptureHDR/CaptureHDR.cs
@@ -19,7 +19,7 @@ class Program
 
             Console.WriteLine("Configuring settings");
             var settings = new Zivid.NET.Settings();
-            foreach (var aperture in new double[] { 11.31, 5.66, 2.83 })
+            foreach (var aperture in new double[] { 9.57, 4.76, 2.59 })
             {
                 Console.WriteLine("Adding acquisition with aperture = " + aperture);
                 var acquisitionSettings = new Zivid.NET.Settings.Acquisition { Aperture = aperture };

--- a/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cs
+++ b/source/Camera/Basic/CaptureHDRCompleteSettings/CaptureHDRCompleteSettings.cs
@@ -41,9 +41,10 @@ class Program
             Console.WriteLine(baseAcquisition);
 
             Console.WriteLine("Configuring acquisition settings different for all HDR acquisitions:");
-            double[] aperture = { 8.0, 4.0, 4.0 };
-            int[] exposureTime = { 10000, 10000, 40000 };
-            double[] gain = { 1.0, 1.0, 2.0 };
+            Tuple<double[], int[], double[]> exposureValues = GetExposureValues(camera);
+            double[] aperture = exposureValues.Item1;
+            int[] exposureTime = exposureValues.Item2;
+            double[] gain = exposureValues.Item3;
             for (int i = 0; i < aperture.Length; i++)
             {
                 Console.WriteLine("Acquisition {0}:", i + 1);
@@ -75,5 +76,24 @@ class Program
             Console.WriteLine("Error: " + ex.Message);
             Environment.ExitCode = 1;
         }
+    }
+
+    static Tuple<double[], int[], double[]> GetExposureValues(Zivid.NET.Camera camera)
+    {
+        if (camera.Info.ModelName.Substring(0, 9) == "Zivid One")
+        {
+            double[] aperture = { 8.0, 4.0, 4.0 };
+            int[] exposureTime = { 10000, 10000, 40000 };
+            double[] gain = { 1.0, 1.0, 2.0 };
+            return Tuple.Create<double[], int[], double[]>(aperture, exposureTime, gain);
+        }
+        if (camera.Info.ModelName.Substring(0, 9) == "Zivid Two")
+        {
+            double[] aperture = { 5.66, 2.38, 1.8 };
+            int[] exposureTime = { 1677, 5000, 100000 };
+            double[] gain = { 1.0, 1.0, 1.0 };
+            return Tuple.Create<double[], int[], double[]>(aperture, exposureTime, gain);
+        }
+        throw new Exception("Unknown camera model, " + camera.Info.ModelName.Substring(0, 9));
     }
 }

--- a/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cs
+++ b/source/Camera/Basic/CaptureWithSettingsFromYML/CaptureWithSettingsFromYML.cs
@@ -18,8 +18,9 @@ class Program
             var camera = zivid.ConnectCamera();
 
             Console.WriteLine("Configuring settings from file");
+            var cameraModel = camera.Info.ModelName.Substring(0, 9);
             var settingsFile = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData)
-                               + "/Zivid/Settings/Settings01.yml";
+                               + "/Zivid/Settings/" + cameraModel + "/Settings01.yml";
             var settings = new Zivid.NET.Settings(settingsFile);
 
             Console.WriteLine("Capturing frame");


### PR DESCRIPTION
This PR is the same as in c++, https://github.com/zivid/zivid-cpp-samples/pull/152

Add logic to check if Zivid One or Zivid Two is connected and use
settings accordingly.
This commit requires an update of ZividSampleData to run the samples
that read settings from file.